### PR TITLE
GDPR cookies and consent

### DIFF
--- a/IMOMaritimeSingleWindow/Client/src/index.html
+++ b/IMOMaritimeSingleWindow/Client/src/index.html
@@ -2,16 +2,7 @@
 <html lang="en">
 
 <head>
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-130169807-1"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'UA-130169807-1');
-</script>
-
+  
   <meta charset="utf-8">
   <title>ImoMaritimeSingleWindow</title>
   <base href="/">


### PR DESCRIPTION
Without a cookie consent opt-in on the frontend, Google Analytics must be removed to comply with Recitals 30 (cookie consent) and 32 (consent) of GDPR