### PR TITLE
increase AppSettings Secrey keysize

### DIFF
--- a/IMOMaritimeSingleWindow/Server/appsettings.default.json
+++ b/IMOMaritimeSingleWindow/Server/appsettings.default.json
@@ -1,9 +1,9 @@
-{
+﻿{
 	"ConnectionStrings": {
-		"OpenSSN": "User ID=postgres;Password=*******;Host=51.144.94.82;Port=5432;Database=imomsw;",
+		"OpenSSN": "User ID=user;Password=;Host=localhost;Port=5432;Database=imomsw;",
 		"UserDatabase": ""
 	},
 	"AppSettings": {
-		"Secret" : "TopSekrit"
+		"Secret" : "TopSekritSecretToken"
 	}
 }


### PR DESCRIPTION
The default Secret keySize is outside the required range, so lets expand it to avoid this for first time deployers

- System.ArgumentOutOfRangeException: IDX10603: The algorithm: 'HS256' requires the SecurityKey.KeySize to be greater than '128' bits. KeySize reported: '72'.